### PR TITLE
Add missing trailing commas to API URLs

### DIFF
--- a/frontend/vre/collection/collection.model.js
+++ b/frontend/vre/collection/collection.model.js
@@ -23,7 +23,7 @@ export var VRECollection = APIModel.extend({
 });
 
 export var VRECollections = APICollection.extend({
-    url: '/api/collections',
+    url: '/api/collections/',
     model: VRECollection,
 }, {
     /**
@@ -31,7 +31,7 @@ export var VRECollections = APICollection.extend({
      */
     mine: function() {
         var myCollections = new VRECollections();
-        myCollections.fetch({url: myCollections.url + '/mine'});
+        myCollections.fetch({url: myCollections.url + 'mine/'});
         return myCollections;
     },
 });

--- a/frontend/vre/group/group.model.js
+++ b/frontend/vre/group/group.model.js
@@ -1,14 +1,14 @@
 import { APICollection } from '../utils/api.model';
 
 export var ResearchGroups = APICollection.extend({
-    url: '/api/researchgroups',
+    url: '/api/researchgroups/',
 }, {
     /**
      * Class method for retrieving only the research groups of the user.
      */
     mine: function() {
         var myResearchGroups = new ResearchGroups();
-        myResearchGroups.fetch({url: myResearchGroups.url + '/mine'});
+        myResearchGroups.fetch({url: myResearchGroups.url + 'mine/'});
         return myResearchGroups;
     },
 });


### PR DESCRIPTION
Without these changes, this trigger:

https://github.com/UUDigitalHumanitieslab/EDPOP/blob/1f5fe3497fc35f24c819122da0a3a6c98e61514d/frontend/vre/main.js#L112

never happens for me, and the collection dropdown is not inserted in the DOM as a result. This is because Django does not recognize the URLs without a trailing slash and defaults to the index page. The collections in question cannot read the HTML and therefore never trigger their `update` events, causing the `finish` trigger to fail.

@tijmenbaarda It is unclear to me why this does not seem to have affected you. Please check whether the application still works for you with these changes. Manually load http://localhost:8000/static/bundle.js first and refresh to make 100% sure that the browser is running the latest code.