### PR TITLE
Show EDPOP Explorer record details

### DIFF
--- a/frontend/vre/css/style.css
+++ b/frontend/vre/css/style.css
@@ -35,3 +35,16 @@ table#hpb-info-table td:nth-child(odd) {
 		width: 636px;
 	}
 }
+
+ul.inline-list {
+	padding-left: 0;
+}
+
+ul.inline-list li {
+	display: inline;
+	text-decoration: none;
+}
+
+ul.inline-list li:not(:first-child)::before {
+	content: " • "
+}

--- a/frontend/vre/edpop-record-ontology.json
+++ b/frontend/vre/edpop-record-ontology.json
@@ -1,0 +1,567 @@
+{
+  "@context": {
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "edpoprec": "https://dhstatic.hum.uu.nl/edpop-records/0.1.0-SNAPSHOT/",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "edpoprec:bibliographicalRecord",
+      "rdfs:subClassOf": {
+        "@id": "_:na743fb6ca02e49568bc2e2bb36208e43b2"
+      }
+    },
+    {
+      "@id": "_:na743fb6ca02e49568bc2e2bb36208e43b2",
+      "@type": "owl:Restriction",
+      "owl:maxCardinality": 1,
+      "owl:onProperty": {
+        "@id": "edpoprec:title"
+      }
+    },
+    {
+      "@id": "edpoprec:size",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:description": "Length in centimeters or other way of measuring size",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Dimensions"
+      }
+    },
+    {
+      "@id": "edpoprec:LocationType",
+      "@type": "rdf:class",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Location type"
+      }
+    },
+    {
+      "@id": "edpoprec:timespan",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BiographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:DatingField"
+      },
+      "skos:description": "The years that the person was alive or the entity was existing",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Timespan"
+      }
+    },
+    {
+      "@id": "edpoprec:physicalDescription",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:description": "Comments about the physical appearance of the described item",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Physical description"
+      }
+    },
+    {
+      "@id": "edpoprec:originalData",
+      "@type": "rdf:Property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Record"
+      },
+      "rdfs:range": {
+        "@id": "rdf:JSON"
+      },
+      "skos:description": "All data from the original catalogue record in JSON format",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Original data"
+      }
+    },
+    {
+      "@id": "edpoprec:Record",
+      "@type": "rdfs:Class",
+      "skos:description": "Bibliographical or biographical record",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Record"
+      }
+    },
+    {
+      "@id": "edpoprec:authorityRecord",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:description": "Link to an authority record as given in the record",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Authority record"
+      }
+    },
+    {
+      "@id": "edpoprec:extent",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:description": "Number of pages or other way of measuring length",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Extent"
+      }
+    },
+    {
+      "@id": "edpoprec:languageCode",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:LanguageField"
+      },
+      "rdfs:range": {
+        "@id": "xsd:string"
+      },
+      "skos:description": "Three-character language code according to ISO 639-3",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Language code"
+      }
+    },
+    {
+      "@id": "edpoprec:variantName",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BiographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Name"
+      }
+    },
+    {
+      "@id": "edpoprec:originalText",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Field"
+      },
+      "rdfs:range": {
+        "@id": "xsd:string"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Original text"
+      }
+    },
+    {
+      "@id": "edpoprec:dating",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:DatingField"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Dating"
+      }
+    },
+    {
+      "@id": "edpoprec:normalizedText",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Field"
+      },
+      "rdfs:range": {
+        "@id": "xsd:string"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Normalized text"
+      }
+    },
+    {
+      "@id": "edpoprec:title",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Title"
+      }
+    },
+    {
+      "@id": "edpoprec:relation",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:ContributorField"
+      },
+      "skos:description": "Role of the contributor (normalized)",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Relation"
+      }
+    },
+    {
+      "@id": "edpoprec:name",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BiographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Name"
+      }
+    },
+    {
+      "@id": "edpoprec:placeOfDeath",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BiographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:LocationField"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Place of death"
+      }
+    },
+    {
+      "@id": "edpoprec:activity",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BiographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:description": "An activity that the entity is known for",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Activity"
+      }
+    },
+    {
+      "@id": "edpoprec:BibliographicalCatalog",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Catalog"
+      },
+      "skos:description": "External repository of bibliographical data",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Bibliographical catalog"
+      }
+    },
+    {
+      "@id": "edpoprec:country",
+      "@type": "edpoprec:LocationType",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Country"
+      }
+    },
+    {
+      "@id": "edpoprec:Field",
+      "@type": "rdf:Class",
+      "rdfs:subClassOf": {
+        "@id": "_:na743fb6ca02e49568bc2e2bb36208e43b1"
+      },
+      "skos:description": "A catalog field",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Field"
+      }
+    },
+    {
+      "@id": "_:na743fb6ca02e49568bc2e2bb36208e43b1",
+      "@type": "owl:Restriction",
+      "owl:cardinality": 1,
+      "owl:onProperty": {
+        "@id": "edpoprec:originalText"
+      }
+    },
+    {
+      "@id": "edpoprec:LanguageField",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Language"
+      }
+    },
+    {
+      "@id": "edpoprec:placeOfActivity",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BiographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:LocationField"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Place of activity"
+      }
+    },
+    {
+      "@id": "edpoprec:ContributorField",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Contributor field"
+      }
+    },
+    {
+      "@id": "edpoprec:",
+      "@type": "owl:Ontology"
+    },
+    {
+      "@id": "edpoprec:BibliographicalRecord",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Record"
+      }
+    },
+    {
+      "@id": "edpoprec:edtfDate",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:DatingField"
+      },
+      "rdfs:range": {
+        "@id": "http://id.loc.gov/datatypes/edtf/EDTF"
+      },
+      "skos:description": "Normalized date in Extended Date/Time Format",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "EDTF date"
+      }
+    },
+    {
+      "@id": "edpoprec:placeOfBirth",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BiographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:LocationField"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Place of birth"
+      }
+    },
+    {
+      "@id": "edpoprec:BiographicalRecord",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Record"
+      }
+    },
+    {
+      "@id": "edpoprec:language",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:LanguageField"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Language"
+      }
+    },
+    {
+      "@id": "edpoprec:locality",
+      "@type": "edpoprec:LocationType",
+      "skos:description": "A place of residence such as a village, town or city",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Locality"
+      }
+    },
+    {
+      "@id": "edpoprec:contributor",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:ContributorField"
+      },
+      "skos:description": "Author or other contributor to the work",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Contributor"
+      }
+    },
+    {
+      "@id": "edpoprec:DatingField",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Dating field"
+      }
+    },
+    {
+      "@id": "edpoprec:LocationField",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:description": "A location, such as a town, country or region",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Location field"
+      }
+    },
+    {
+      "@id": "edpoprec:identifier",
+      "@type": "rdf:Property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Record"
+      },
+      "skos:description": "Unique identifier used by the source catalog",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Identifier"
+      }
+    },
+    {
+      "@id": "edpoprec:publisherOrPrinter",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:LocationField"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Publisher or printer"
+      }
+    },
+    {
+      "@id": "edpoprec:unknown",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Field"
+      },
+      "rdfs:range": {
+        "@id": "xsd:boolean"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Unknown"
+      }
+    },
+    {
+      "@id": "edpoprec:alternativeTitle",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Alternative title"
+      }
+    },
+    {
+      "@id": "edpoprec:placeOfPublication",
+      "@type": "rdf:property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:LocationField"
+      },
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Place of publication"
+      }
+    },
+    {
+      "@id": "edpoprec:BiographicalCatalog",
+      "rdfs:subClassOf": {
+        "@id": "edpoprec:Catalog"
+      },
+      "skos:description": "External repository of biographical data",
+      "skos:preflabel": {
+        "@language": "en",
+        "@value": "Biographical catalog"
+      }
+    },
+    {
+      "@id": "edpoprec:Catalog",
+      "@type": "rdfs:Class",
+      "skos:description": "External repository of bibliographical or biographical data",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Catalog"
+      }
+    },
+    {
+      "@id": "edpoprec:publicURL",
+      "@type": "rdf:Property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Record"
+      },
+      "rdfs:range": {
+        "@id": "xsd:anyURI"
+      },
+      "skos:description": "Public URL in the source catalog",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Public URL"
+      }
+    },
+    {
+      "@id": "edpoprec:fromCatalog",
+      "@type": "rdf:Property",
+      "rdfs:domain": {
+        "@id": "edpoprec:Record"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Catalog"
+      },
+      "skos:description": "The catalog this record was originally taken from",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "From catalog"
+      }
+    }
+  ]
+}

--- a/frontend/vre/field/field.view.js
+++ b/frontend/vre/field/field.view.js
@@ -17,7 +17,19 @@ export var FieldView = View.extend({
     },
 
     render: function() {
-        this.$el.html(this.template(this.model.attributes));
+        const templateData = {
+            field: this.model.get('key'),
+        };
+        // Check if model is of Field model before using these methods, because
+        // there are some tests relating to old-style annotations that assign
+        // custom models
+        if (typeof this.model.getMainDisplay === 'function') {
+            Object.assign(templateData, {
+                displayText: this.model.getMainDisplay(),
+                fieldInfo: this.model.getFieldInfo(),
+            });
+        }
+        this.$el.html(this.template(templateData));
         return this;
     },
 

--- a/frontend/vre/field/field.view.mustache
+++ b/frontend/vre/field/field.view.mustache
@@ -1,3 +1,3 @@
-<td><u>{{key}}</u></td>
-<td>{{value}}</td>
+<td><u title="{{fieldInfo.description}}">{{fieldInfo.name}}</u></td>
+<td>{{displayText}}</td>
 {{#context}}<td>{{context}}</td>{{/context}}

--- a/frontend/vre/field/field.view.test.js
+++ b/frontend/vre/field/field.view.test.js
@@ -3,12 +3,17 @@ import sinon from 'sinon';
 import { each } from 'lodash';
 import { Model } from 'backbone';
 import { FieldView } from './field.view';
+import {Record} from "../record/record.model";
+import {Field} from "./field.model";
 
 describe('FieldView', function() {
     beforeEach(function() {
-        this.model = new Model({
-            key: 'Color',
-            value: 'green',
+        this.model = new Field({
+            'key': 'edpoprec:Color',
+            'value': {
+                '@type': 'edpoprec:Field',
+                'edpoprec:originalText': 'green',
+            },
             context: 'me, myself and I',
         });
         this.view = new FieldView({model: this.model});
@@ -18,23 +23,30 @@ describe('FieldView', function() {
         this.view.remove();
     });
 
-    it('renders with the contents of its model', function() {
+    it('renders with the contents of the field', function() {
         var text = this.view.$el.text();
-        each(this.model.toJSON(), function(attributeValue) {
-            assert(text.includes(attributeValue));
-        });
+        assert(text.includes(this.model.getMainDisplay()));
+    });
+
+    it('renders with the display name of the field type', function() {
+        var text = this.view.$el.text();
+        assert(text.includes(this.model.getFieldInfo().name));
     });
 
     it('updates when the value attribute changes', function() {
         var oldText = this.view.$el.text();
-        var oldValue = this.model.get('value');
-        var newValue = 'red';
+        var oldExpectedTest = this.model.getMainDisplay();
+        var newValue = {
+            '@type': 'edpoprec:Field',
+            'edpoprec:originalText': 'red',
+        };
+        var newExpectedText = 'red';
         this.model.set('value', newValue);
         var newText = this.view.$el.text();
         assert(newText !== oldText);
-        assert(!oldText.includes(newValue));
-        assert(newText.includes(newValue));
-        assert(!newText.includes(oldValue));
+        assert(!oldText.includes(newExpectedText));
+        assert(newText.includes(newExpectedText));
+        assert(!newText.includes(oldExpectedTest));
     });
 
     it('triggers an edit event when clicked', function() {

--- a/frontend/vre/field/record.fields.view.js
+++ b/frontend/vre/field/record.fields.view.js
@@ -1,7 +1,7 @@
 import { RecordFieldsBaseView } from './record.base.view';
 
 export var RecordFieldsView = RecordFieldsBaseView.extend({
-    title: 'Original content',
+    title: 'Normalized content',
     edit: function(model) {
         this.trigger('edit', model);
     },

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -49,7 +49,10 @@ export var RecordDetailView = CompositeView.extend({
     },
 
     renderContainer: function() {
-        this.$el.html(this.template(this.model.toJSON()));
+        console.log(this.model);
+        this.$el.html(this.template({
+            title: this.model.getMainDisplay(),
+        }));
         return this;
     },
 

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -52,6 +52,9 @@ export var RecordDetailView = CompositeView.extend({
         console.log(this.model);
         this.$el.html(this.template({
             title: this.model.getMainDisplay(),
+            uri: this.model.id,
+            databaseId: this.model.get("edpoprec:identifier"),
+            publicURL: this.model.get("edpoprec:publicURL"),
         }));
         return this;
     },

--- a/frontend/vre/record/record.detail.view.mustache
+++ b/frontend/vre/record/record.detail.view.mustache
@@ -13,9 +13,7 @@
                 data-dismiss="modal"
                 aria-label="Close"
             ><span aria-hidden="true">&times;</span></button>
-            <a id="uri-link" target="blank" href="{{&uri}}">
-                <h4 class="modal-title">{{uri}}</h4>
-            </a>
+            <h4 class="modal-title">{{title}}</h4>
         </div>
         <div class="modal-body"></div>
         <div class="modal-footer">

--- a/frontend/vre/record/record.detail.view.mustache
+++ b/frontend/vre/record/record.detail.view.mustache
@@ -14,6 +14,10 @@
                 aria-label="Close"
             ><span aria-hidden="true">&times;</span></button>
             <h4 class="modal-title">{{title}}</h4>
+            <ul class="inline-list">
+                {{#databaseId}}<li>ID in database: {{databaseId}}</li>{{/databaseId}}
+                {{#publicURL}}<li><a href="{{publicURL}}" target="_blank">Show record in original database</a></li>{{/publicURL}}
+            </ul>
         </div>
         <div class="modal-body"></div>
         <div class="modal-footer">

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -29,7 +29,7 @@ export function getStringLiteral(literalObject) {
         if (typeof item === "string" && agg === null) {
             // If a string (data type xsd:string), only prefer this value if no other value was chosen yet.
             return item;
-        } else if (Object.hasOwn(item, "@language") && Object.hasOwn(item, "@value")) {
+        } else if (typeof(item) === "object" && Object.hasOwn(item, "@language") && Object.hasOwn(item, "@value")) {
             // This is a language-tagged string. Prefer it if no other value was chosen yet, OR if it matches
             // the language of the user interface. Only support English for now.
             const language = item["@language"];

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -10,6 +10,38 @@ import {APICollection} from "./api.model";
  * @typedef {Object} JSONLDSubject
  */
 
+
+/**
+ * Get a string literal from JSON-LD. This function probes whether the literal
+ * is of xsd:string or rdf:langString format and if multiple string literals
+ * are given. In the latter case, return only one string with a preference
+ * for an rdf:langString that matches the user interface's language.
+ * If no string literal is found, return null.
+ * @param literalObject
+ * @return {?string}
+ */
+export function getStringLiteral(literalObject) {
+    // If the property occurs multiple time, literalObject is an array. Normalize to array.
+    if (!Array.isArray(literalObject)) {
+        literalObject = [literalObject];
+    }
+    return literalObject.reduce((agg, item) => {
+        if (typeof item === "string" && agg === null) {
+            // If a string (data type xsd:string), only prefer this value if no other value was chosen yet.
+            return item;
+        } else if (Object.hasOwn(item, "@language") && Object.hasOwn(item, "@value")) {
+            // This is a language-tagged string. Prefer it if no other value was chosen yet, OR if it matches
+            // the language of the user interface. Only support English for now.
+            const language = item["@language"];
+            if (agg === null || language.startsWith("en")) {
+                return item["@value"];
+            }
+        } else {
+            return agg;
+        }
+    }, null);
+}
+
 export var JsonLdModel = Backbone.Model.extend({
     idAttribute: '@id',
 });
@@ -55,6 +87,33 @@ export function nestSubject(subjectsByID, subject, parentSubjectIDs=[]) {
     parentSubjectIDs.pop();
     return transformedSubject;
 }
+
+/**
+ * Generic subclass of APICollection that parses incoming compacted JSON-LD to an
+ * array of subjects that are of RDF class `targetClass`. If these subjects
+ * refer to other objects, these are nested
+ */
+export var JsonLdNestedCollection = APICollection.extend({
+    model: JsonLdModel,
+    /**
+     * The RDF class (as it is named in JSON-LD) of which nested subjects have to be
+     * put in the collection array when incoming data is parsed.
+     * @type {string}
+     */
+    targetClass: undefined,
+    parse: function(response) {
+        if (!response.hasOwnProperty("@graph")) {
+            throw "Response has no @graph key, is this JSON-LD in compacted form?";
+        }
+        if (typeof this.targetClass === "undefined") {
+            throw "targetClass should not be undefined"
+        }
+        const allSubjects = response["@graph"];
+        const subjectsByID = _.keyBy(allSubjects, '@id'); // NOTE: change to indexBy when migrating to underscore
+        const targetedSubjectIDs = allSubjects.filter(subject => subject["@type"] === this.targetClass).map(subject => subject["@id"]);
+        return targetedSubjectIDs.map(subjectID => nestSubject(subjectsByID, subjectsByID[subjectID]));
+    }
+})
 
 /**
  * Generic subclass of APICollection that parses incoming compacted JSON-LD to an

--- a/frontend/vre/utils/jsonld.model.test.js
+++ b/frontend/vre/utils/jsonld.model.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import sinon from 'sinon';
-import {nestSubject} from "./jsonld.model";
+import {getStringLiteral, nestSubject} from "./jsonld.model";
 
 function findById(graph, id) {
     return graph.find((subject) => subject["@id"] === id);
@@ -104,5 +104,35 @@ describe('nestSubject', () => {
         const subject = subjectsByID["http://example.com/s7"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal("http://example.com/descForS7", ns["dc:description"]["owl:sameAs"]["owl:sameAs"]["@id"]);
+    });
+});
+
+describe('getStringLiteral', () => {
+    it ('returns null in case of an empty array', () => {
+        assert(getStringLiteral([]) === null);
+    });
+    it ('returns the string in case of just a string', () => {
+        assert(getStringLiteral("hoi") === "hoi");
+    });
+    it ('returns the string in case of just a langString', () => {
+        assert(getStringLiteral({
+            "@language": "nl",
+            "@value": "hallo",
+        }) === "hallo");
+    });
+    it ('returns the first string in case of an array of two strings', () => {
+        assert(getStringLiteral(['hoi', 'hallo']) === 'hoi');
+    });
+    it ('returns the English string in case of an array of multiple langString, including one in English', () => {
+        assert(getStringLiteral([{
+            "@language": "nl",
+            "@value": "hallo",
+        }]), getStringLiteral([{
+            "@language": "en",
+            "@value": "hello",
+        }]), getStringLiteral([{
+            "@language": "fr",
+            "@value": "bonjour",
+        }]) === "hello");
     });
 });

--- a/frontend/vre/utils/record-ontology.js
+++ b/frontend/vre/utils/record-ontology.js
@@ -1,0 +1,16 @@
+/**
+ * Models, collections and utilities related to the record ontology.
+ */
+
+import {JsonLdNestedCollection} from "./jsonld.model";
+
+/**
+ * A Backbone collection to access the properties defined by the ontology.
+ */
+export var PropertyList = JsonLdNestedCollection.extend({
+    url: "/static/edpop-record-ontology.json",
+    targetClass: "rdf:property",
+});
+
+export var properties = new PropertyList();
+properties.fetch();


### PR DESCRIPTION
The display names of the record fields are taken from the EDPOP record ontology.

I created a simple reader for these property names -- I realized that to do it properly will get quite complex very soon. My main doubt here is where to put the ontology (or, a JSON-LD version of it):
* Compile it into the JavaScript bundle (probably the most efficient)
* Take it live from dhstatic
* Add it as a static file and read it from there (my current approach - this was the easiest to implement)