### PR TITLE
Basic frontend collection management

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+indent_style = space
+indent_size = 4
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**/package.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ db*
 
 # Visual Studio Code
 .vscode/
+
+# emacs
+.\#*
+*~
+\#*\#

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -93,7 +93,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://www.npmjs.com/search?q=keywords:karma-launcher
-    browsers: ['ChromeHeadless'],
+    browsers: [],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
@@ -114,7 +114,7 @@ module.exports = function(config) {
     },
 
   };
-  
+
   if (process.env.CI) {
     configuration.browsers = ['ChromeHeadless'];
     configuration.singleRun = true;

--- a/frontend/vre/alert/alert.view.js
+++ b/frontend/vre/alert/alert.view.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 import alertTemplate from './alert.view.mustache';
 
 /**

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -1,4 +1,4 @@
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 import annotationEditTemplate from './annotation.edit.view.mustache';
 import confirmDeletionTemplate from './annotation.confirm.deletion.mustache';
 

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,7 +1,7 @@
 import  Backbone from 'backbone';
 import { APIModel, APICollection } from '../utils/api.model';
 import { canonicalSort } from '../utils/generic-functions';
-import { GlobalVariables } from '../globals/variables';
+import { vreChannel } from '../radio.js';
 
 export var Annotations = APICollection.extend({
     url: '/api/annotations',
@@ -37,7 +37,7 @@ export var FlatAnnotations = APICollection.extend({
         }
         var id = annotation.id,
             projectId = annotation.get('context'),
-            projectName = GlobalVariables.allProjects.get(projectId).get('name'),
+            projectName = vreChannel.request('projects:get', projectId).get('name'),
             content = annotation.get('content'),
             existing = _.map(this.filter({ context: projectName }), 'attributes'),
             replacements = _.map(content, function(value, key) {
@@ -59,7 +59,7 @@ export var FlatAnnotations = APICollection.extend({
             recordId = record.id,
             flatPerProject = flat.groupBy('context');
         var newContent = flat.markedProjects.map('id').map(function (projectName) {
-            var projectId = GlobalVariables.allProjects.findWhere({ name: projectName }).id,
+            var projectId = vreChannel.request('projects:find', { name: projectName }).id,
                 existing = flat.underlying.findWhere({ context: projectId }),
                 id = existing && existing.id,
                 annotations = flatPerProject[projectName],

--- a/frontend/vre/catalog/collection.search.view.js
+++ b/frontend/vre/catalog/collection.search.view.js
@@ -1,4 +1,4 @@
-import { CompositeView } from 'backbone-fractal';
+import { CompositeView } from '../core/view.js';
 
 import { SearchResults } from '../search/search.model.js';
 import { SearchView } from '../search/search.view.js';

--- a/frontend/vre/catalog/select-catalog.view.js
+++ b/frontend/vre/catalog/select-catalog.view.js
@@ -1,5 +1,5 @@
 import Backbone from 'backbone';
-import { CollectionView as AggregateView } from 'backbone-fractal';
+import { AggregateView } from '../core/view.js';
 
 import optionDBTemplate from './select-catalog-option.view.mustache';
 import selectDBTemplate from './select-catalog.view.mustache';

--- a/frontend/vre/collection/browse-collection.view.js
+++ b/frontend/vre/collection/browse-collection.view.js
@@ -1,4 +1,4 @@
-import { CompositeView } from 'backbone-fractal';
+import { CompositeView } from '../core/view.js';
 
 import { SearchResults } from '../search/search.model.js';
 import { SearchView } from '../search/search.view.js';

--- a/frontend/vre/collection/browse-collection.view.js
+++ b/frontend/vre/collection/browse-collection.view.js
@@ -3,14 +3,23 @@ import { CompositeView } from '../core/view.js';
 import { SearchResults } from '../search/search.model.js';
 import { SearchView } from '../search/search.view.js';
 import { RecordListManagingView } from '../record/record.list.managing.view.js';
+import { OverlayView } from '../utils/overlay.view.js';
+import { EditSummaryView } from './edit-summary.view.js';
 import collectionTemplate from './browse-collection.view.mustache';
 
 export var BrowseCollectionView = CompositeView.extend({
     template: collectionTemplate,
+
+    events: {
+        'click .page-header small button': 'editSummary',
+    },
+
     subviews: [
         {view: 'searchView', selector: '.page-header'},
         'recordsManager',
+        {view: 'editOverlay', place: false},
     ],
+
     initialize: function() {
         this.collection = this.collection || new SearchResults;
         this.searchView = new SearchView({
@@ -21,10 +30,23 @@ export var BrowseCollectionView = CompositeView.extend({
             collection: this.collection
         });
         this.model.getRecords(this.collection);
-        this.render();
+        var editor = new EditSummaryView({model: this.model});
+        var overlay = this.editOverlay = new OverlayView({
+            root: this.el,
+            target: '.page-header h2 small',
+            guest: editor,
+        });
+        overlay.listenTo(editor, 'submit reset', overlay.uncover);
+        this.render().listenTo(this.model, 'change', this.render);
     },
+
     renderContainer: function() {
         this.$el.html(this.template(this.model.attributes));
+        return this;
+    },
+
+    editSummary: function() {
+        this.editOverlay.cover();
         return this;
     },
 });

--- a/frontend/vre/collection/browse-collection.view.mustache
+++ b/frontend/vre/collection/browse-collection.view.mustache
@@ -1,3 +1,3 @@
 <div class="page-header" id="title-collection">
-    <h2>Search or browse {{description}}</h2>
+    <h2>Search or browse {{name}}</h2>
 </div>

--- a/frontend/vre/collection/browse-collection.view.mustache
+++ b/frontend/vre/collection/browse-collection.view.mustache
@@ -1,3 +1,8 @@
 <div class="page-header" id="title-collection">
-    <h2>Collection {{name}} <small>{{summary}}</small></h2>
+    <h2>Collection {{name}} <small>
+        {{summary}}
+        <button type=button class="btn btn-default btn-sm" aria-label="Edit summary">
+            <span class="glyphicon glyphicon-pencil" aria-hidden=true></span>
+        </button>
+    </small></h2>
 </div>

--- a/frontend/vre/collection/browse-collection.view.mustache
+++ b/frontend/vre/collection/browse-collection.view.mustache
@@ -1,3 +1,3 @@
 <div class="page-header" id="title-collection">
-    <h2>Search or browse {{name}} <small>{{summary}}</small></h2>
+    <h2>Collection {{name}} <small>{{summary}}</small></h2>
 </div>

--- a/frontend/vre/collection/browse-collection.view.mustache
+++ b/frontend/vre/collection/browse-collection.view.mustache
@@ -1,3 +1,3 @@
 <div class="page-header" id="title-collection">
-    <h2>Search or browse {{name}}</h2>
+    <h2>Search or browse {{name}} <small>{{summary}}</small></h2>
 </div>

--- a/frontend/vre/collection/collection.model.js
+++ b/frontend/vre/collection/collection.model.js
@@ -6,6 +6,7 @@ import { Records } from '../record/record.model.js';
  * Representation of a single VRE collection.
  */
 export var VRECollection = APIModel.extend({
+    idAttribute: 'uri',
     getRecords: function(records) {
         if (!records) {
             if (this.records) return this.records;

--- a/frontend/vre/collection/collection.model.js
+++ b/frontend/vre/collection/collection.model.js
@@ -33,7 +33,7 @@ export var VRECollections = APICollection.extend({
      */
     mine: function(myCollections) {
         myCollections = myCollections || new VRECollections();
-        myCollections.fetch({url: myCollections.url + 'mine/'});
+        myCollections.fetch();
         return myCollections;
     },
 });

--- a/frontend/vre/collection/collection.view.js
+++ b/frontend/vre/collection/collection.view.js
@@ -1,4 +1,4 @@
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 import { AlertView } from '../alert/alert.view';
 import { AdditionsToCollections } from '../additions/additions-to-collections';
 import { GlobalVariables } from '../globals/variables';

--- a/frontend/vre/collection/edit-summary.view.js
+++ b/frontend/vre/collection/edit-summary.view.js
@@ -3,7 +3,7 @@ import editSummaryTemplate from './edit-summary.view.mustache';
 
 export var EditSummaryView = View.extend({
     tagName: 'form',
-    className: 'form-inline',
+    className: 'form-inline inline-editor',
     template: editSummaryTemplate,
 
     events: {

--- a/frontend/vre/collection/edit-summary.view.js
+++ b/frontend/vre/collection/edit-summary.view.js
@@ -1,0 +1,41 @@
+import { View } from '../core/view.js';
+import editSummaryTemplate from './edit-summary.view.mustache';
+
+export var EditSummaryView = View.extend({
+    tagName: 'form',
+    className: 'form-inline',
+    template: editSummaryTemplate,
+
+    events: {
+        submit: 'submit',
+        reset: 'reset',
+    },
+
+    initialize: function() {
+        this.render();
+    },
+
+    render: function() {
+        this.$el.html(this.template(this));
+        this.fillValue();
+        return this;
+    },
+
+    fillValue: function() {
+        this.$('input').val(this.model.get('summary'));
+    },
+
+    submit: function(event) {
+        event.preventDefault();
+        var payload = {
+            summary: this.$('input').val(),
+        };
+        this.trigger('submit', payload);
+        this.model.save(payload, {wait: true});
+    },
+
+    reset: function(event) {
+        event.preventDefault();
+        this.trigger('reset').fillValue();
+    },
+});

--- a/frontend/vre/collection/edit-summary.view.mustache
+++ b/frontend/vre/collection/edit-summary.view.mustache
@@ -1,0 +1,21 @@
+<div class="form-group">
+    <label
+        for=summary-{{&cid}}
+        class="sr-only"
+    >Collection summary</label>
+    <input
+        type=text
+        name=summary
+        placeholder="Collection summary"
+        id=summary-{{&cid}}
+        class="form-control"
+    >
+</div>
+<button
+    type=submit
+    class="btn btn-primary"
+>Save</button>
+<button
+    type=reset
+    class="btn btn-default"
+>Cancel</button>

--- a/frontend/vre/collection/select-collection-option.view.mustache
+++ b/frontend/vre/collection/select-collection-option.view.mustache
@@ -1,1 +1,1 @@
-<a href="/collection/{{id}}/" id="{{id}}">{{description}}</a>
+<a href="/collection/{{name}}/" id="{{name}}">{{name}}</a>

--- a/frontend/vre/collection/select-collection.view.js
+++ b/frontend/vre/collection/select-collection.view.js
@@ -1,5 +1,5 @@
 import Backbone from 'backbone';
-import { CollectionView as AggregateView } from 'backbone-fractal';
+import { AggregateView } from '../core/view.js';
 
 import optionDBTemplate from './select-collection-option.view.mustache';
 import selectDBTemplate from './select-collection.view.mustache';

--- a/frontend/vre/collection/select-collection.view.js
+++ b/frontend/vre/collection/select-collection.view.js
@@ -1,6 +1,8 @@
+import _ from 'lodash';
 import Backbone from 'backbone';
 import { AggregateView } from '../core/view.js';
 
+import { vreChannel } from '../radio.js';
 import optionDBTemplate from './select-collection-option.view.mustache';
 import selectDBTemplate from './select-collection.view.mustache';
 
@@ -40,11 +42,29 @@ export var SelectCollectionView = AggregateView.extend({
     className: 'dropdown',
     subview: CollectionOptionView,
     container: 'ul',
+    events: {
+        'submit .dropdown-menu form': 'createCollection',
+    },
     initialize: function() {
         this.initItems().render().initCollectionEvents();
     },
     renderContainer: function() {
-        this.$el.html(this.template());
+        this.$el.html(this.template(this));
         return this;
+    },
+    placeItems: function() {
+        this._container.prepend(_.map(this.items, 'el'));
+        return this;
+    },
+    createCollection: function(event) {
+        event.preventDefault();
+        var project = vreChannel.request('projects:current');
+        var input = this.$('.dropdown-menu form input');
+        var name = input.val();
+        this.collection.create({
+            name: name,
+            project: project.get('name'),
+        });
+        input.val('');
     },
 });

--- a/frontend/vre/collection/select-collection.view.mustache
+++ b/frontend/vre/collection/select-collection.view.mustache
@@ -1,4 +1,24 @@
 <a href="" class="dropdown-toggle" data-toggle="dropdown"
     id="collection-menu-title" aria-haspopup="true" aria-expanded="false">Collections <span class="caret"></span>
 </a>
-<ul class="dropdown-menu"></ul>
+<ul class="dropdown-menu">
+    <li role=separator class="divider"></li>
+    <li>
+        <form class="form-inline">
+            <div class="form-group">
+                 <label for=collection-name-{{&cid}} class="sr-only">
+                      Name
+                 </label>
+                 <input
+                     type=text
+                     id=collection-name-{{&cid}}
+                     placeholder="Name"
+                     class="form-control"
+                 >
+            </div>
+            <button type=submit class="btn btn-primary btn-sm" aria-label="Create">
+                <span class="glyphicon glyphicon-plus" aria-hidden=true></span>
+            </button>
+        </form>
+    </li>
+</ul>

--- a/frontend/vre/core/view.js
+++ b/frontend/vre/core/view.js
@@ -1,20 +1,30 @@
 import _ from 'lodash';
 import { View as BBView } from 'backbone';
+import { CompositeView as FComposite, CollectionView } from 'backbone-fractal';
 import { getAltClickMixin } from '@uu-cdh/backbone-util';
 
-/**
- * Common base class for all of our views.
- * Among other things, it enables alt-click debugging.
- * @class
- */
-export var View = BBView.extend(_.extend(getAltClickMixin(), {
-    constructor: function(options) {
-        View.call(this, options);
-        this.enableAltClick();
-    },
+function mix(Base) {
+    return Base.extend(_.extend(getAltClickMixin(), {
+        constructor: function(options) {
+            Base.call(this, options);
+            this.enableAltClick();
+        },
 
-    remove: function() {
-        this.$el.off('click');
-        return View.prototype.remove.call(this);
-    },
-}));
+        remove: function() {
+            this.$el.off('click');
+            return Base.prototype.remove.call(this);
+        },
+    }));
+}
+
+/**
+ * Common base classes for all of our views.
+ * Among other things, they enable alt-click debugging.
+ */
+
+/** @class */
+export var View = mix(BBView);
+/** @class */
+export var CompositeView = mix(FComposite);
+/** @class */
+export var AggregateView = mix(CollectionView);

--- a/frontend/vre/core/view.js
+++ b/frontend/vre/core/view.js
@@ -1,0 +1,20 @@
+import _ from 'lodash';
+import { View as BBView } from 'backbone';
+import { getAltClickMixin } from '@uu-cdh/backbone-util';
+
+/**
+ * Common base class for all of our views.
+ * Among other things, it enables alt-click debugging.
+ * @class
+ */
+export var View = BBView.extend(_.extend(getAltClickMixin(), {
+    constructor: function(options) {
+        View.call(this, options);
+        this.enableAltClick();
+    },
+
+    remove: function() {
+        this.$el.off('click');
+        return View.prototype.remove.call(this);
+    },
+}));

--- a/frontend/vre/css/style.css
+++ b/frontend/vre/css/style.css
@@ -49,6 +49,10 @@ ul.inline-list li:not(:first-child)::before {
     content: " • "
 }
 
+form.form-inline.inline-editor {
+    display: inline-block;
+}
+
 @media (prefers-color-scheme: dark) {
     html {
         filter: invert(1) hue-rotate(180deg) contrast(0.9) brightness(0.9);

--- a/frontend/vre/css/style.css
+++ b/frontend/vre/css/style.css
@@ -48,3 +48,12 @@ ul.inline-list li {
 ul.inline-list li:not(:first-child)::before {
     content: " • "
 }
+
+@media (prefers-color-scheme: dark) {
+    html {
+        filter: invert(1) hue-rotate(180deg) contrast(0.9) brightness(0.9);
+    }
+    img, video {
+        filter: hue-rotate(180deg) invert(1);
+    }
+}

--- a/frontend/vre/css/style.css
+++ b/frontend/vre/css/style.css
@@ -53,6 +53,11 @@ form.form-inline.inline-editor {
     display: inline-block;
 }
 
+.dropdown-menu > li > form {
+    padding: 3px 20px;
+    width: max-content;
+}
+
 @media (prefers-color-scheme: dark) {
     html {
         filter: invert(1) hue-rotate(180deg) contrast(0.9) brightness(0.9);

--- a/frontend/vre/field/field.view.js
+++ b/frontend/vre/field/field.view.js
@@ -1,4 +1,4 @@
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 import fieldTemplate from './field.view.mustache';
 
 /**

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Backbone from 'backbone';
 import { AnnotationEditView } from '../annotation/annotation.edit.view';
-import { GlobalVariables } from '../globals/variables';
+import { vreChannel } from '../radio.js';
 import { RecordFieldsBaseView } from './record.base.view';
 
 export var RecordAnnotationsView = RecordFieldsBaseView.extend({
@@ -17,7 +17,7 @@ export var RecordAnnotationsView = RecordFieldsBaseView.extend({
     },
 
     edit: function(model) {
-        var project = GlobalVariables.projectMenu.model.get('name'),
+        var project = vreChannel.request('projects:current').get('name'),
             editTarget = model.clone().set('context', project),
             preExisting = this.collection.get(editTarget),
             newRow;

--- a/frontend/vre/field/record.annotations.view.test.js
+++ b/frontend/vre/field/record.annotations.view.test.js
@@ -2,7 +2,8 @@ import assert from 'assert';
 import sinon from 'sinon';
 import { isEmpty, last, indexOf, find, compact } from 'lodash';
 import { Collection }  from 'backbone';
-import { GlobalVariables } from '../globals/variables';
+
+import { vreChannel } from '../radio.js';
 import { FlatAnnotations } from '../annotation/annotation.model.js';
 import { AnnotationEditView } from '../annotation/annotation.edit.view.js';
 import { RecordFieldsBaseView } from './record.base.view.js';
@@ -117,8 +118,7 @@ function newAnnotationTrashed() {
 
 describe('RecordAnnotationsView', function() {
     before(function() {
-        assert(isEmpty(GlobalVariables));
-        GlobalVariables.projectMenu = fakeProjectMenu;
+        vreChannel.reply('projects:current', () => fakeProjectMenu.model);
     });
 
     beforeEach(function() {
@@ -137,7 +137,7 @@ describe('RecordAnnotationsView', function() {
     });
 
     after(function() {
-        delete GlobalVariables.projectMenu;
+        vreChannel.stopReplying('projects:current');
     });
 
     it('inherits from RecordFieldsBaseView', function() {

--- a/frontend/vre/field/record.base.view.js
+++ b/frontend/vre/field/record.base.view.js
@@ -1,8 +1,8 @@
-import { CollectionView } from 'backbone-fractal';
+import { AggregateView } from '../core/view.js';
 import { FieldView } from './field.view';
 import fieldListTemplate from './record.base.view.mustache';
 
-export var RecordFieldsBaseView = CollectionView.extend({
+export var RecordFieldsBaseView = AggregateView.extend({
     template: fieldListTemplate,
     container: 'tbody',
 

--- a/frontend/vre/globals/projects.js
+++ b/frontend/vre/globals/projects.js
@@ -1,0 +1,29 @@
+import { vreChannel } from '../radio.js';
+import { Projects } from '../project/project.model.js';
+import { ProjectMenuView } from '../project/project.menu.view';
+
+var allProjects = new Projects;
+var myProjects, projectMenu;
+
+function fetch(callback) {
+    allProjects.fetch();
+    myProjects = Projects.mine();
+    projectMenu = new ProjectMenuView({collection: myProjects});
+    allProjects.once('sync', callback);
+}
+
+function select(name) {
+    projectMenu.select(name);
+}
+
+function currentProject() {
+    return projectMenu.model;
+}
+
+vreChannel.reply({
+    'projects:fetch': fetch,
+    'projects:select': select,
+    'projects:get': allProjects.get.bind(allProjects),
+    'projects:find': allProjects.find.bind(allProjects),
+    'projects:current': currentProject,
+});

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -82,6 +82,8 @@ catalogs.on({
 
 function showCollection(vreCollection) {
     GlobalVariables.currentVRECollection = vreCollection;
+    // The next line is not very MVC, but it works for now.
+    GlobalVariables.projectMenu.select(vreCollection.get('project'));
     navigationState.set(
         'browser', new BrowseCollectionView({model: vreCollection}));
 }

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -58,7 +58,7 @@ var router = new VRERouter();
 // of attention.
 router.on({
     'route:showCollection': id => navigationState.set(
-        'browsingContext', GlobalVariables.myCollections.get(id)),
+        'browsingContext', GlobalVariables.myCollections.find({name: id})),
     'route:showCatalog': id => navigationState.set(
         'browsingContext', catalogs.findWhere({identifier: id})),
 });

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -13,21 +13,18 @@ import { BlankRecordButtonView } from './record/blank.record.button.view';
 import { VRECollections } from './collection/collection.model';
 import { CollectionSearchView } from './catalog/collection.search.view';
 import { BrowseCollectionView } from './collection/browse-collection.view';
-import { Projects } from './project/project.model';
-import { ProjectMenuView } from './project/project.menu.view';
-
 
 import { SelectCollectionView } from './collection/select-collection.view';
 import { GlobalVariables } from './globals/variables';
 import './globals/user';
+import './globals/projects.js';
 import { accountMenu } from './globals/accountMenu';
 import {Catalogs} from "./catalog/catalog.model";
 import {SelectCatalogView} from "./catalog/select-catalog.view";
 import { StateModel } from './utils/state.model.js';
 import { WelcomeView } from './utils/welcome.view.js';
 
-// Dangerously global variables (accessible from dependency modules).
-GlobalVariables.allProjects = new Projects();
+// Dangerously global variable (accessible from dependency modules).
 GlobalVariables.myCollections = new VRECollections();
 
 // Regular global variables, only visible in this module.
@@ -83,7 +80,7 @@ catalogs.on({
 function showCollection(vreCollection) {
     GlobalVariables.currentVRECollection = vreCollection;
     // The next line is not very MVC, but it works for now.
-    GlobalVariables.projectMenu.select(vreCollection.get('project'));
+    vreChannel.request('projects:select', vreCollection.get('project'));
     navigationState.set(
         'browser', new BrowseCollectionView({model: vreCollection}));
 }
@@ -100,11 +97,8 @@ function prepareCollections() {
     $('#result-detail').modal({show: false});
     VRECollections.mine(GlobalVariables.myCollections);
     catalogs.fetch();
-    GlobalVariables.allProjects.fetch();
-    var myProjects = Projects.mine();
-    GlobalVariables.projectMenu = new ProjectMenuView({ collection: myProjects });
+    vreChannel.request('projects:fetch', finish);
     GlobalVariables.myCollections.on('sync', finish);
-    GlobalVariables.allProjects.on('sync', finish);
     catalogs.on('sync', finish);
 
     // Add account menu
@@ -114,8 +108,7 @@ function prepareCollections() {
 }
 
 // We want this code to run after prepareCollections has run and both
-// GlobalVariables.myCollections and GlobalVariables.allProjects have fully
-// loaded.
+// GlobalVariables.myCollections and all projects have fully loaded.
 function startRouting() {
     $('.nav').first().append(
         catalogDropdown.el,

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -4,6 +4,9 @@ import Backbone from 'backbone';
 import Cookies from 'jscookie';
 import { wrapWithCSRF } from '@uu-cdh/backbone-util';
 
+// Enable alt-click debugging (outcomment to disable).
+window.DEBUGGING = true;
+
 import './record/record.opening.aspect';
 import { vreChannel } from './radio';
 import { BlankRecordButtonView } from './record/blank.record.button.view';
@@ -22,7 +25,6 @@ import {Catalogs} from "./catalog/catalog.model";
 import {SelectCatalogView} from "./catalog/select-catalog.view";
 import { StateModel } from './utils/state.model.js';
 import { WelcomeView } from './utils/welcome.view.js';
-
 
 // Dangerously global variables (accessible from dependency modules).
 GlobalVariables.allProjects = new Projects();

--- a/frontend/vre/project/project.menu.item.view.js
+++ b/frontend/vre/project/project.menu.item.view.js
@@ -1,4 +1,4 @@
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 import projectMenuItemTemplate from './project.menu.item.view.mustache';
 
 export var ProjectMenuItemView = View.extend({

--- a/frontend/vre/project/project.menu.view.js
+++ b/frontend/vre/project/project.menu.view.js
@@ -50,6 +50,6 @@ export var ProjectMenuView = AggregateView.extend({
         this.model = model;
         this.renderContainer();
         this.trigger('select', model);
-        localStorage.setItem('project', model.attributes.id);
+        localStorage.setItem('project', model.id);
     },
 });

--- a/frontend/vre/project/project.menu.view.js
+++ b/frontend/vre/project/project.menu.view.js
@@ -40,6 +40,9 @@ export var ProjectMenuView = AggregateView.extend({
     },
 
     select: function (model) {
+        // At this point, `model` could either be an instance of `Project` or
+        // just an id. The next line ensures that it is a full-blown instance
+        // (or `undefined`).
         model = this.collection.get(model);
         if (!model) return;
         if (model === this.model) return;

--- a/frontend/vre/project/project.menu.view.js
+++ b/frontend/vre/project/project.menu.view.js
@@ -40,6 +40,8 @@ export var ProjectMenuView = AggregateView.extend({
     },
 
     select: function (model) {
+        model = this.collection.get(model);
+        if (!model) return;
         if (model === this.model) return;
         if (this.model) this.model.trigger('deselect');
         this.model = model;

--- a/frontend/vre/project/project.menu.view.js
+++ b/frontend/vre/project/project.menu.view.js
@@ -1,9 +1,9 @@
-import { CollectionView } from 'backbone-fractal';
+import { AggregateView } from '../core/view.js';
 
 import { ProjectMenuItemView } from './project.menu.item.view';
 import projectMenuTemplate from './project.menu.view.mustache';
 
-export var ProjectMenuView = CollectionView.extend({
+export var ProjectMenuView = AggregateView.extend({
     el: '#vre-project-menu',
     template: projectMenuTemplate,
     subview: ProjectMenuItemView,

--- a/frontend/vre/project/project.menu.view.mustache
+++ b/frontend/vre/project/project.menu.view.mustache
@@ -1,1 +1,1 @@
-<b>Annotation Context</b>: {{name}}<span class=caret></span>
+<b>Project</b>: {{name}}<span class=caret></span>

--- a/frontend/vre/project/project.model.js
+++ b/frontend/vre/project/project.model.js
@@ -1,7 +1,12 @@
-import { APICollection } from '../utils/api.model';
+import { APIModel, APICollection } from '../utils/api.model';
+
+export var Project = APIModel.extend({
+    idAttribute: 'name',
+});
 
 export var Projects = APICollection.extend({
     url: '/api/projects/',
+    model: Project,
 }, {
     mine: function () {
         var myProjects = new Projects();

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -1,4 +1,4 @@
-import { CompositeView } from 'backbone-fractal';
+import { CompositeView } from '../core/view.js';
 import { vreChannel } from '../radio';
 import { FlatAnnotations } from '../annotation/annotation.model';
 import { RecordFieldsView } from '../field/record.fields.view';

--- a/frontend/vre/record/record.list.managing.view.js
+++ b/frontend/vre/record/record.list.managing.view.js
@@ -1,4 +1,4 @@
-import { CompositeView } from 'backbone-fractal';
+import { CompositeView } from '../core/view.js';
 import { VRECollectionView } from '../collection/collection.view';
 import { GlobalVariables } from '../globals/variables';
 import recordListManagingTemplate from './record.list.managing.view.mustache';

--- a/frontend/vre/search/advanced.search.view.js
+++ b/frontend/vre/search/advanced.search.view.js
@@ -1,4 +1,4 @@
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 import advancedSearchTemplate from './advanced.search.view.mustache';
 
 export var AdvancedSearchView = View.extend({

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -1,4 +1,4 @@
-import { CompositeView } from 'backbone-fractal';
+import { CompositeView } from '../core/view.js';
 
 import { AlertView } from '../alert/alert.view';
 import searchViewTemplate from './search.view.mustache';

--- a/frontend/vre/user/account.menu.view.js
+++ b/frontend/vre/user/account.menu.view.js
@@ -1,4 +1,4 @@
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 import accountMenuTemplate from './account.menu.view.mustache';
 
 export var AccountMenuView = View.extend({

--- a/frontend/vre/utils/api.model.js
+++ b/frontend/vre/utils/api.model.js
@@ -1,4 +1,5 @@
 import Backbone from 'backbone';
+import { modelSlashUrl } from '@uu-cdh/backbone-util';
 import { objectAsUrlParams } from './generic-functions';
 
 /**
@@ -6,9 +7,7 @@ import { objectAsUrlParams } from './generic-functions';
  * This is required for interop with Django REST Framework.
  */
 export var APIModel = Backbone.Model.extend({
-    url: function() {
-        return Backbone.Model.prototype.url.call(this) + '/';
-    },
+    url: modelSlashUrl(),
 });
 
 /**

--- a/frontend/vre/utils/overlay.view.js
+++ b/frontend/vre/utils/overlay.view.js
@@ -1,0 +1,45 @@
+import _ from 'lodash';
+import { View, $ } from 'backbone';
+
+var targetAbsent = 'Overlay target selector does not match any element';
+var guestAbsent = 'Overlay guest view disappeared from DOM';
+
+export var OverlayView = View.extend({
+    initialize: function(options) {
+        _.extend(this, _.pick(options, ['target', 'guest']));
+        this.root = $(options.root);
+        this.listenTo(this.guest, 'all', this.trigger);
+    },
+
+    cover: function() {
+        if (this.covered) return false;
+        var covered = this.root.find(this.target).first();
+        if (!covered.length) throw Error(targetAbsent);
+        covered.after(this.guest.el).detach();
+        this.covered = covered;
+        return true;
+    },
+
+    uncover: function() {
+        if (!this.covered) return false;
+        if (!this.root.find(this.guest.el).length) throw Error(guestAbsent);
+        this.guest.$el.before(this.covered).detach();
+        delete this.covered;
+        return true;
+    },
+
+    toggle: function() {
+        this.cover() || this.uncover();
+        return this;
+    },
+
+    isActive: function() {
+        return !!this.covered;
+    },
+
+    remove: function() {
+        this.uncover();
+        this.guest.remove();
+        return View.prototype.remove.call(this);
+    },
+});

--- a/frontend/vre/utils/overlay.view.test.js
+++ b/frontend/vre/utils/overlay.view.test.js
@@ -1,0 +1,142 @@
+import assert from 'assert';
+import sinon from 'sinon';
+
+import { View } from 'backbone';
+
+import { OverlayView } from './overlay.view.js';
+
+describe('OverlayView', function() {
+    var overlayer, guest, host, spy;
+
+    before(function() {
+        guest = new View({tagName: 'p'});
+        guest.$el.text('replacement');
+        host = new View;
+        host.$el.html('<p>original</p>');
+    });
+
+    after(function() {
+        host.remove();
+        guest.remove();
+    });
+
+    beforeEach(function() {
+        overlayer = new OverlayView({
+            root: host.el,
+            target: 'p',
+            guest: guest,
+        });
+    });
+
+    afterEach(function() {
+        spy = null;
+        overlayer.remove();
+    });
+
+    function assertNotCovered() {
+        assert(host.$el.text().match('original'));
+        assert(!host.$el.text().match('replacement'));
+        assert(!overlayer.isActive());
+    }
+
+    function assertCovered() {
+        assert(!host.$el.text().match('original'));
+        assert(host.$el.text().match('replacement'));
+        assert(overlayer.isActive());
+    }
+
+    function assertIntegrity() {
+        var targetElement = overlayer.covered || host.$('p');
+        assert(guest.$el.text() === 'replacement');
+        assert(targetElement.text() === 'original');
+    }
+
+    it('does not overlay the guest immediately', assertNotCovered);
+
+    it('forwards events from the guest view', function() {
+        spy = sinon.fake();
+        overlayer.on('test', spy);
+        assert(spy.notCalled);
+        guest.trigger('test');
+        assert(spy.calledOnce);
+    });
+
+    describe('cover', function() {
+        beforeEach(function() {
+            overlayer.cover();
+        });
+
+        it('substitutes the guest element for the target', assertCovered);
+
+        it('has no adverse side effects', assertIntegrity);
+
+        it('is idempotent', function() {
+            overlayer.cover();
+            assertCovered();
+            assertIntegrity();
+        });
+
+        it('works after a previous uncover', function() {
+            overlayer.uncover();
+            overlayer.cover();
+            assertCovered();
+            assertIntegrity();
+        });
+    });
+
+    describe('uncover', function() {
+        beforeEach(function() {
+            overlayer.uncover();
+        });
+
+        it('is a no-op initially', assertNotCovered);
+
+        it('has no adverse side effects', assertIntegrity);
+
+        it('is idempotent', function() {
+            overlayer.uncover();
+            assertNotCovered();
+            assertIntegrity();
+        });
+
+        it('works after a previous cover', function() {
+            overlayer.cover();
+            overlayer.uncover();
+            assertNotCovered();
+            assertIntegrity();
+        });
+    });
+
+    describe('toggle', function() {
+        beforeEach(function() {
+            overlayer.toggle();
+        });
+
+        it('covers the first time', assertCovered);
+
+        it('uncovers the second time', function() {
+            overlayer.toggle();
+            assertNotCovered();
+        });
+
+        it('covers the third time', function() {
+            overlayer.toggle().toggle();
+            assertCovered();
+        });
+    });
+
+    describe('remove', function() {
+        it('calls remove on the guest view', function() {
+            guest.remove = sinon.fake(guest.remove);
+            overlayer.remove();
+            assert(guest.remove.calledOnce);
+        });
+
+        it('restores the original situation', function() {
+            overlayer.cover();
+            overlayer.remove();
+            assertNotCovered();
+            assertIntegrity();
+        });
+    });
+});

--- a/frontend/vre/utils/welcome.view.js
+++ b/frontend/vre/utils/welcome.view.js
@@ -1,4 +1,4 @@
-import { View } from 'backbone';
+import { View } from '../core/view.js';
 
 import welcomeTemplate from './welcome.view.mustache';
 


### PR DESCRIPTION
While frontend collection handling forms the overarching story of this branch, it is a bit of a hodgepodge of small changes:

- Fixed #224 (restores ability to list and display collections).
    - Adjusted existing models, views and other parts to the changed field names.
    - Changed the project menu to automatically switch to the project of the current collection, since each collection can now be associated with only one project.
    - Made the `summary` of a collection visible through a `<small>` insertion in the page header.
    - Abolished the conceptual difference between "my collections" and "all collections", because the backend endpoint will never list collections beyond the ones the user has access to.
    - Set the `idAttribute` of the Backbone model that represents a single VRE collection to `uri`.
- Minimally implemented #225 (create and partial update only).
    - Added an inline form to the bottom of the collection menu that lets the user quickly whip up new empty collections.
    - Added an inline form that can be temporarily overlaid over the `<small>` in the page header in order to adjust the `summary` of a collection.
        - Created a separate, generic, reusable `OverlayView` in order to support this. It can do one thing: temporarily replace an arbitrary DOM element by an arbitrary view, based on a selector relative to a persistent root element.
- Other fixes, refactorings, cosmetic changes and enhancements (mostly just to give myself an easier time while working on the above changes).
    - Enabled [alt-click debugging](https://github.com/CentreForDigitalHumanities/backbone-util/blob/develop/doc/click-to-debug.md) for all views (with the exception of views that aren't reachable by mouse, such as `OverlayView` instances).
    - Set the `idAttribute` of the `Project` model to `name`. It appears that the `idAttribute` was never set to a correct value before this.
    - Added an `.editorconfig`.
    - Added temporary files generated by emacs (which I use) to the `.gitignore`.
    - Renamed the "annotation context" menu to just "project", because I felt this conveys the meaning of the menu better.
    - Wrote "Collection" instead of "Browse or search" in the header of the collection page, because I think this signals more clearly to the user what they are viewing.
    - Added a provisional auto dark mode.
    - Removed `headlessChrome` from the default browsers in the Karma config as discussed in https://github.com/UUDigitalHumanitieslab/EDPOP/pull/200#discussion_r1740803381.
    - Removed the project menu and associated collections from the `GlobalVariables`, using the `vreChannel` instead for loose coupling. This brings us a bit closer to #123 again.
    - Replaced the old, simple but faulty logic for appending trailing slashes to model URLs by the more sophisticated and thoroughly tested [`modelSlashUrl`](https://github.com/CentreForDigitalHumanities/backbone-util/blob/develop/doc/trailing-slash.md) from backbone-util.

I will be on vacation soon, so I prioritized fast delivery over comprehensiveness. Hence, there are some omissions and rough edges that I am aware of:

- Collections cannot be deleted. I think this should eventually be possible, but it needs to be designed carefully to minimize the risk that users accidentally lose a lot of work.
- The name of a collection cannot be changed. I opted out of this because I did not want the name and the uri to diverge. In the future, users could conceivably work around this by adding all records from one collection to another and then deleting the source collection.
- A project must be selected before you can create a collection. If no project is selected, collection creation silently fails, ~~but an entry with the new name still appears in the menu.~~
- There is no validation or error handing for the create and update actions.

There are also things that were already broken on `develop` and which are not fixed by this branch:

- Collections created before #181 are not visible because of #226.
- There is no way to add or list records in collections because the records endpoint still has to be updated.
- Project selection should probably be more prominent.

For review, I suggest giving the frontend a quick spin and just scrolling through the code changes. There are lots of files with only minor changes, but I think you will be able to quickly identify repeating patterns and skip over those.