### PR TITLE
Docker change

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-bullseye
 
 WORKDIR /usr/src/app/backend
-COPY requirements.txt requirements-test.txt .
+COPY requirements.txt requirements-test.txt ./
 RUN pip install -U pip pip-tools && \
     pip-sync requirements.txt requirements-test.txt
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16
 
 WORKDIR /usr/src/app
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm install
 
 COPY . .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,3 +5,5 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 COPY . .
+
+USER node


### PR DESCRIPTION
I tried building and running the frontend via Docker with `docker compose up frontend`, but this failed:

> frontend-1    | bundles vre/main.js → vre/bundle.js...
> frontend-1    | [!] (plugin commonjs--resolver) Error: EACCES: permission denied, stat '/root/.node_modules/vre'
> frontend-1    | Error: EACCES: permission denied, stat '/root/.node_modules/vre'

Running the frontend container as the [unprivileged `node` user](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user) fixes this.

As an aside, is there a benefit to storing the node_modules as a volume rather than just having it in the built container?