### PR TITLE
Make all properties available in Tabulator records list, show record type with icon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
         volumes:
             - pgdata:/var/lib/postgresql/data
             - ./backend/create_db.sql:/docker-entrypoint-initdb.d/edpop.sql
-        ports:
-            - 127.0.0.1:5432:5432
     blazegraph:
         image: islandora/blazegraph:main
         healthcheck:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@uu-cdh/backbone-collection-transformers": "github:CentreForDigitalHumanities/backbone-collection-transformers#release/0.1.0",
         "@uu-cdh/backbone-util": "^0.1.1",
         "backbone": "^1.3.3",
         "backbone-fractal": "^1.1.1",
@@ -996,6 +997,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/@uu-cdh/backbone-collection-transformers": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/CentreForDigitalHumanities/backbone-collection-transformers.git#3fc171057445e8b0d6b62fd4bff5d9982238a04d",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@uu-cdh/backbone-util": "^0.1.1",
+        "backbone": "^1.6.0",
+        "underscore": "^1.13.6"
+      }
     },
     "node_modules/@uu-cdh/backbone-util": {
       "version": "0.1.1",
@@ -5313,6 +5324,15 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@uu-cdh/backbone-collection-transformers": {
+      "version": "git+ssh://git@github.com/CentreForDigitalHumanities/backbone-collection-transformers.git#3fc171057445e8b0d6b62fd4bff5d9982238a04d",
+      "from": "@uu-cdh/backbone-collection-transformers@github:CentreForDigitalHumanities/backbone-collection-transformers#release/0.1.0",
+      "requires": {
+        "@uu-cdh/backbone-util": "^0.1.1",
+        "backbone": "^1.6.0",
+        "underscore": "^1.13.6"
+      }
     },
     "@uu-cdh/backbone-util": {
       "version": "0.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "sinon": "^14.0.1"
   },
   "dependencies": {
+    "@uu-cdh/backbone-collection-transformers": "github:CentreForDigitalHumanities/backbone-collection-transformers#release/0.1.0",
     "@uu-cdh/backbone-util": "^0.1.1",
     "backbone": "^1.3.3",
     "backbone-fractal": "^1.1.1",

--- a/frontend/vre/edpop-record-ontology.json
+++ b/frontend/vre/edpop-record-ontology.json
@@ -11,7 +11,7 @@
   },
   "@graph": [
     {
-      "@id": "edpoprec:bibliographicalRecord",
+      "@id": "edpoprec:BibliographicalRecord",
       "rdfs:subClassOf": {
         "@id": "_:na743fb6ca02e49568bc2e2bb36208e43b2"
       }

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -1,33 +1,7 @@
 import Backbone from "backbone";
-import {properties} from "../utils/record-ontology";
-import {getStringLiteral} from "../utils/jsonld.model";
 import {vreChannel} from "../radio";
 import Tabulator from "tabulator";
-import {columnChooseMenu} from "../utils/tabulator-utils";
-
-const columnProperties = {
-    'edpoprec:title': {
-        visible: true,
-        widthGrow: 5,
-        formatter: 'textarea',
-    },
-    'edpoprec:placeOfPublication': {
-        visible: true,
-    },
-    'edpoprec:dating': {
-        visible: true,
-        widthGrow: 0.5,
-    },
-    'edpoprec:publisherOrPrinter': {
-        visible: true,
-    },
-    'edpoprec:contributor': {
-        visible: true,
-    },
-    'edpoprec:activity': {
-        visible: true,
-    },
-};
+import {adjustDefinitions} from "../utils/tabulator-utils";
 
 export var RecordListView = Backbone.View.extend({
     id: "record-list",
@@ -48,23 +22,7 @@ export var RecordListView = Backbone.View.extend({
             height: 650, // set height of table (in CSS or here), this enables the Virtual DOM and improves render speed dramatically (can be any valid css height value)
             data: initialData,
             autoColumns: true,
-            autoColumnsDefinitions: (definitions) => {
-                for (let definition of definitions) {
-                    // All columns invisible by default
-                    definition.visible = false;
-                    const property = properties.get(definition.field);
-                    if (property) {
-                        definition.title = getStringLiteral(property.get("skos:prefLabel"));
-                    }
-                    definition.headerFilter = true;
-                    definition.headerContextMenu = columnChooseMenu;
-                    const hardcodedProperties = columnProperties[definition.field];
-                    if (hardcodedProperties) {
-                        Object.assign(definition, hardcodedProperties);
-                    }
-                }
-                return definitions;
-            },
+            autoColumnsDefinitions: adjustDefinitions,
             layout: "fitColumns",
             rowHeader: {
                 width: 50,

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -29,6 +29,7 @@ export var Record = JsonLdModel.extend({
         const fields = new FlatFields(undefined, {record: this});
         const data = {
             model: this,
+            type: this.get('@type'),
         };
         fields.forEach((field) => {
             data[field.id] = field.getMainDisplay();

--- a/frontend/vre/record/record.type.icon.mustache
+++ b/frontend/vre/record/record.type.icon.mustache
@@ -1,0 +1,8 @@
+{{#isBibliographical}}
+<span class="glyphicon glyphicon-book" aria-hidden=true></span>
+<span class="sr-only">Bibliographical</span>
+{{/isBibliographical}}
+{{#isBiographical}}
+<span class="glyphicon glyphicon-user" aria-hidden=true></span>
+<span class="sr-only">Biographical</span>
+{{/isBiographical}}

--- a/frontend/vre/utils/mapped.collection.js
+++ b/frontend/vre/utils/mapped.collection.js
@@ -1,0 +1,25 @@
+import { Collection } from 'backbone';
+import { deriveMapped } from '@uu-cdh/backbone-collection-transformers';
+
+/**
+ * @class
+ * @extends Collection
+ */
+export var MappedCollection = deriveMapped();
+
+function clone(model) {
+    return model.clone();
+}
+
+// MappedCollection is not clonable by default. In our case, it is useful to
+// have a deep copy feature available.
+/**
+ * Create a deep copy of the models in the collection.
+ * @returns {Collection} A plain (i.e., non-mapped, non-proxy) collection that
+ * has no ties to the original mapped or collection or its underlying
+ * collection.
+ */
+MappedCollection.prototype.clone = function() {
+    var clonedModels = this.map(clone);
+    return new Collection(clonedModels);
+}

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -1,3 +1,7 @@
+import _ from 'lodash';
+import {properties} from './record-ontology';
+import {getStringLiteral} from './jsonld.model';
+
 /**
  * A Tabulator menu to hide and show the available columns.
  * Adapted from: https://tabulator.info/examples/6.2#menu
@@ -57,3 +61,50 @@ export const columnChooseMenu = function(){
 
     return menu;
 };
+
+const defaultColumnFeatures = {
+    visible: false,
+    headerFilter: true,
+    headerContextMenu: columnChooseMenu,
+};
+
+const columnProperties = {
+    'edpoprec:title': {
+        visible: true,
+        widthGrow: 5,
+        formatter: 'textarea',
+    },
+    'edpoprec:placeOfPublication': {
+        visible: true,
+    },
+    'edpoprec:dating': {
+        visible: true,
+        widthGrow: 0.5,
+    },
+    'edpoprec:publisherOrPrinter': {
+        visible: true,
+    },
+    'edpoprec:contributor': {
+        visible: true,
+    },
+    'edpoprec:activity': {
+        visible: true,
+    },
+};
+
+function adjustDefinition(bareDefinition) {
+    const property = properties.get(bareDefinition.field);
+    const addedTitle = property ? {
+        title: getStringLiteral(property.get('skos:prefLabel')),
+    } : null;
+    const customProperties = columnProperties[bareDefinition.field];
+    return _.assign(
+        {},
+        bareDefinition,
+        defaultColumnFeatures,
+        addedTitle,
+        customProperties
+    );
+}
+
+export const adjustDefinitions = _.partial(_.map, _, adjustDefinition);

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -73,7 +73,6 @@ const defaultColumnFeatures = {
 const columnProperties = {
     'edpoprec:title': {
         widthGrow: 5,
-        formatter: 'textarea',
     },
     'edpoprec:placeOfPublication': {},
     'edpoprec:dating': {

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -3,6 +3,7 @@ import {Model, Collection} from 'backbone';
 import {MappedCollection} from './mapped.collection.js';
 import {properties} from './record-ontology';
 import {getStringLiteral} from './jsonld.model';
+import recordTypeIcon from '../record/record.type.icon.mustache';
 
 /**
  * A Tabulator menu to hide and show the available columns.
@@ -64,6 +65,11 @@ export const columnChooseMenu = function(){
     return menu;
 };
 
+const typeTranslation = {
+    'edpoprec:BibliographicalRecord': {isBibliographical: true},
+    'edpoprec:BiographicalRecord': {isBiographical: true},
+};
+
 const defaultColumnFeatures = {
     visible: false,
     headerFilter: true,
@@ -71,6 +77,7 @@ const defaultColumnFeatures = {
 };
 
 const columnProperties = {
+    type: {},
     'edpoprec:title': {
         widthGrow: 5,
     },
@@ -106,6 +113,18 @@ const standardColumns = new MappedCollection(
     property2definition,
     {model: ColumnDefinition, comparator: byPreference},
 );
+
+standardColumns.unshift({
+    field: 'type',
+    title: 'Type',
+    visible: true,
+    headerContextMenu: columnChooseMenu,
+    formatter: cell => recordTypeIcon(typeTranslation[cell.getValue()]),
+    hozAlign: 'right',
+    tooltip: (e, cell) => cell.getValue().slice(9, -6),
+    width: 48,
+    _ucid: {},
+}, {convert: false});
 
 export function adjustDefinitions(autodetected) {
     const customizedColumns = standardColumns.clone();


### PR DESCRIPTION
This implements half of #229 and half of #228. Showing record types or all properties in the detail view is not yet implemented, although some of the logic introduced in this branch could be reused for that purpose. I wanted to go all the way, but did not manage to go beyond the record list because of time constraints and distractions.

The `autoColumnsDefinitions` callback from `frontend/vre/record/record.list.view.js` was outfactored to `frontend/vre/utils/tabulator-utils.js` and then extended to always include all possible properties as available columns. The set of *visible* columns is still determined in the same way, though the decision to make a column visible now happens in a different place. For the extended logic, I used the `MappedCollection` feature from the freshly outfactored, still-to-be-released [backbone-collection-transformers](https://github.com/CentreForDigitalHumanities/backbone-collection-transformers).

Then, I added an icon column to convey the record type: a person silhouette for a biographical record, a book for a bibliographical record. The HTML for the icon is rendered using a Mustache template. That template is potentially reusable for a `Backbone.View`. The HTML includes textual labels for screen readers. Record types are indicated at the individual record level rather than the catalog level, because I seemed to recall that some catalogs are mixed.

The new code lacks tests, but it has a low complexity and I hope it is sufficiently documented.

This branch has some side effects:

- The docker-compose `postgres` service port is no longer forwarded to the host. This was never necessary to make docker-compose work. The reason to remove it is that it somehow prevented me from starting the container.
- I turned the filter input for the Title column from a `<textarea>` back into a default `<input>`, because the height difference with other columns annoyed me.
- I fixed a typo in the `edpop-record-ontology.json` that I discovered by coincidence.

As an aside, I notice that `edpoprec:BiographicalRecord` is a subclass of `edpoprec:Record` while `edpoprec:BibliographicalRecord` isn't. Conversely, `BibliographicalRecord` has a cardinality constraint while `BiographicalRecord` doesn't. I did not address this because I didn't know whether it was merely an oversight or whether there was a good reason for it.