### PR TITLE
Repeated fields

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
     postgres:
         image: postgres:14

--- a/frontend/vre/field/field.model.js
+++ b/frontend/vre/field/field.model.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import Backbone from 'backbone';
 import {
     canonicalSort,
@@ -21,7 +22,11 @@ export var Field = Backbone.Model.extend({
     getMainDisplay() {
         // Currently, only normalizedText is supported.
         const value = this.get('value');
-        return value && value['edpoprec:originalText'];
+        if (!value) return value;
+        if (_.isArray(value)) {
+            return _.map(value, 'edpoprec:originalText').join(' ; ');
+        }
+        return value['edpoprec:originalText'];
     },
     getFieldInfo() {
         const property = properties.get(this.id);

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -4,7 +4,7 @@ import { vreChannel } from '../radio';
 import { FlatAnnotations } from '../annotation/annotation.model';
 import { RecordFieldsView } from '../field/record.fields.view';
 import { RecordAnnotationsView } from '../field/record.annotations.view';
-import { FlatFields } from '../field/field.model';
+import { FlatterFields } from '../field/field.model';
 import { VRECollectionView } from '../collection/collection.view';
 import { typeTranslation } from '../utils/generic-functions.js';
 import { GlobalVariables } from '../globals/variables';
@@ -44,7 +44,7 @@ export var RecordDetailView = CompositeView.extend({
     initialize: function(options) {
         var model = this.model;
         this.fieldsView = new RecordFieldsView({
-            collection: new FlatFields(null, {record: model}),
+            collection: new FlatterFields(null, {record: model}),
         }).render();
         this.annotationsView = new RecordAnnotationsView({
             collection: new FlatAnnotations(null, {record: model}),

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -79,7 +79,6 @@ export function nestSubject(subjectsByID, subject) {
         if (!dereferenced) return subject;
         if (_.includes(parentSubjectIDs, id)) return subject;
         parentSubjectIDs.push(id);
-        const nest = _.partial(nestSubject, subjectsByID, _, parentSubjectIDs);
         const transformedSubject = _.mapValues(dereferenced, nestProperty);
         parentSubjectIDs.pop();
         return transformedSubject;

--- a/frontend/vre/utils/jsonld.model.test.js
+++ b/frontend/vre/utils/jsonld.model.test.js
@@ -95,7 +95,7 @@ describe('nestSubject', () => {
         assert.equal("Random description", ns["dc:description"]["example:value"]["example:value"]);
     });
 
-    it('does not resolve a recursive reference', () => {
+    it('does not resolve a cyclical reference', () => {
         const subject = subjectsByID["http://example.com/s5"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal("http://example.com/s5", ns["owl:sameAs"]["owl:sameAs"]["@id"]);

--- a/frontend/vre/utils/jsonld.model.test.js
+++ b/frontend/vre/utils/jsonld.model.test.js
@@ -66,6 +66,16 @@ const exampleJsonLDGraph = [{
     "owl:sameAs": {
         "@id": "http://example.com/descForS7",
     },
+}, {
+    "@id": "http://example.com/s8",
+    "dc:title": "Title with nested array",
+    "dc:description": [{
+        "@id": "http://example.com/descForS2",
+    }, {
+        "@id": "http://example.com/descForS4",
+    }, {
+        "@id": "http://example.com/descForS7",
+    }],
 }];
 
 describe('nestSubject', () => {
@@ -105,6 +115,14 @@ describe('nestSubject', () => {
         const subject = subjectsByID["http://example.com/s7"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal("http://example.com/descForS7", ns["dc:description"]["owl:sameAs"]["owl:sameAs"]["@id"]);
+    });
+
+    it('can handle arrays of internal references', () => {
+        const subject = subjectsByID["http://example.com/s8"];
+        const ns = nestSubject(subjectsByID, subject);
+        assert.equal("Random description", ns["dc:description"][0]["example:value"]);
+        assert.equal("Random description", ns["dc:description"][1]["example:value"]["example:value"]);
+        assert.equal("http://example.com/descForS7", ns["dc:description"][2]["owl:sameAs"]["owl:sameAs"]["@id"]);
     });
 });
 

--- a/frontend/vre/utils/jsonld.model.test.js
+++ b/frontend/vre/utils/jsonld.model.test.js
@@ -69,38 +69,39 @@ const exampleJsonLDGraph = [{
 }];
 
 describe('nestSubject', () => {
+    const subjectsByID = _.keyBy(exampleJsonLDGraph, "@id");
+
     it('does not change anything if there are no references', () => {
-        const subjectsByID = _.keyBy(exampleJsonLDGraph, "@id");
         const subject = subjectsByID["http://example.com/s1"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal(ns["dc:title"], "Title without references");
     });
+
     it('correctly handles internal references', () => {
-        const subjectsByID = _.keyBy(exampleJsonLDGraph, "@id");
         const subject = subjectsByID["http://example.com/s2"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal("Random description", ns["dc:description"]["example:value"]);
     });
+
     it('does not alter external references', () => {
-        const subjectsByID = _.keyBy(exampleJsonLDGraph, "@id");
         const subject = subjectsByID["http://example.com/s3"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal(subject["dc:description"], ns["dc:description"]);
     });
+
     it('correctly handles a nested internal reference', () => {
-        const subjectsByID = _.keyBy(exampleJsonLDGraph, "@id");
         const subject = subjectsByID["http://example.com/s4"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal("Random description", ns["dc:description"]["example:value"]["example:value"]);
     });
+
     it('does not resolve a recursive reference', () => {
-        const subjectsByID = _.keyBy(exampleJsonLDGraph, "@id");
         const subject = subjectsByID["http://example.com/s5"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal("http://example.com/s5", ns["owl:sameAs"]["owl:sameAs"]["@id"]);
     });
+
     it('detects cycles even if the root subject is not involved', () => {
-        const subjectsByID = _.keyBy(exampleJsonLDGraph, "@id");
         const subject = subjectsByID["http://example.com/s7"];
         const ns = nestSubject(subjectsByID, subject);
         assert.equal("http://example.com/descForS7", ns["dc:description"]["owl:sameAs"]["owl:sameAs"]["@id"]);


### PR DESCRIPTION
Fixes #240 and implements #232. I took #236 into account: separate field values can be individually clicked for annotation, although the actual annotating has not been implemented yet.

It may seem as if rewrote the `nestSubject` function from scratch. I did not; the change was spread over two commits where each commit was an evolutionary change from the previous situation.